### PR TITLE
Query baking and in memory DB open.

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -2,6 +2,7 @@ Import('env')
 
 module_env = env.Clone()
 
+module_env.Append(CPPDEFINES=[('SQLITE_USE_URI', 1)])
 module_env.Prepend(CPPPATH=['#thirdparty/sqlite/thirdparty/sqlite'])
 module_env.Append(CPPDEFINES=["SQLITE_ENABLE_JSON1"])
 

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -5,6 +5,7 @@
 
 void register_sqlite_types() {
 	ClassDB::register_class<SQLite>();
+	ClassDB::register_class<SQLiteQuery>();
 }
 
 void unregister_sqlite_types() {

--- a/sqlite.cpp
+++ b/sqlite.cpp
@@ -175,7 +175,7 @@ void SQLiteQuery::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_last_error_message"), &SQLiteQuery::get_last_error_message);
 	ClassDB::bind_method(D_METHOD("execute", "arguments"), &SQLiteQuery::execute, DEFVAL(Array()));
 	ClassDB::bind_method(D_METHOD("batch_execute", "rows"), &SQLiteQuery::batch_execute);
-	ClassDB::bind_method(D_METHOD("get_columns"), &SQLiteQuery::get_columns)
+	ClassDB::bind_method(D_METHOD("get_columns"), &SQLiteQuery::get_columns);
 }
 
 SQLite::SQLite() {

--- a/sqlite.cpp
+++ b/sqlite.cpp
@@ -127,6 +127,28 @@ Variant SQLiteQuery::batch_execute(Array p_rows) {
 	return res;
 }
 
+Array SQLiteQuery::get_columns() {
+	if (is_ready() == false) {
+		ERR_FAIL_COND_V(prepare() == false, Array());
+	}
+
+	// At this point stmt can't be null.
+	CRASH_COND(stmt == nullptr);
+
+	Array res;
+	const int col_count = sqlite3_column_count(stmt);
+	res.resize(col_count);
+
+	// Fetch all column
+	for (int i = 0; i < col_count; i++) {
+		// Key name
+		const char *col_name = sqlite3_column_name(stmt, i);
+		res[i] = String(col_name);
+	}
+
+	return res;
+}
+
 bool SQLiteQuery::prepare() {
 
 	ERR_FAIL_COND_V(stmt != nullptr, false);
@@ -153,6 +175,7 @@ void SQLiteQuery::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_last_error_message"), &SQLiteQuery::get_last_error_message);
 	ClassDB::bind_method(D_METHOD("execute", "arguments"), &SQLiteQuery::execute, DEFVAL(Array()));
 	ClassDB::bind_method(D_METHOD("batch_execute", "rows"), &SQLiteQuery::batch_execute);
+	ClassDB::bind_method(D_METHOD("get_columns"), &SQLiteQuery::get_columns)
 }
 
 SQLite::SQLite() {

--- a/sqlite.h
+++ b/sqlite.h
@@ -66,6 +66,9 @@ public:
 	/// Returns: `[[0,1], [1,2], [2,3]]`
 	Variant batch_execute(Array p_rows);
 
+	/// Return the list of columns of this query.
+	Array get_columns()
+
 	void finalize();
 
 private:

--- a/sqlite.h
+++ b/sqlite.h
@@ -67,7 +67,7 @@ public:
 	Variant batch_execute(Array p_rows);
 
 	/// Return the list of columns of this query.
-	Array get_columns()
+	Array get_columns();
 
 	void finalize();
 

--- a/sqlite.h
+++ b/sqlite.h
@@ -2,14 +2,80 @@
 #define GDSQLITE_H
 
 #include "core/engine.h"
+#include "core/vector.h"
 #include "core/reference.h"
 
 // SQLite3
 #include "thirdparty/sqlite/spmemvfs.h"
 #include "thirdparty/sqlite/sqlite3.h"
 
+class SQLite;
+
+class SQLiteQuery : public Reference {
+	GDCLASS(SQLiteQuery, Reference);
+
+	SQLite *db = nullptr;
+	sqlite3_stmt *stmt = nullptr;
+	String query;
+
+protected:
+	static void _bind_methods();
+
+public:
+	SQLiteQuery();
+	~SQLiteQuery();
+
+	void init(SQLite *p_db, const String &p_query);
+
+	bool is_ready() const;
+
+	/// Returns the last error message.
+	String get_last_error_message() const;
+
+	/// Executes the query.
+	/// ```
+	/// var query = db.create_query("SELECT * FROM table_name;")
+	/// print(query.execute())
+	/// # prints: [[0, 1], [1, 1], [2, 1]]
+	/// ```
+	///
+	/// You can also pass some arguments:
+	/// ```
+	/// var query = db.create_query("INSERT INTO table_name (column1, column2) VALUES (?, ?); ")
+	/// print(query.execute([0,1]))
+	/// # prints: []
+	/// ```
+	///
+	/// In case of error, a Variant() is returned and the error is logged.
+	/// You can also use `get_last_error_message()` to retrieve the message.
+	Variant execute(Array p_args = Array());
+
+	/// Expects an array of arguments array.
+	/// Executes N times the query, for N array.
+	/// ```
+	/// var query = db.create_query("INSERT INTO table_name (column1, column2) VALUES (?, ?); ")
+	/// query.batch_execute([[0,1], [1,2], [2,3]])
+	/// ```
+	/// The above script insert 3 rows.
+	///
+	/// Also works with a select:
+	/// ```
+	/// var query = db.create_query("SELECT * FROM table_name WHERE column1 = ?;")
+	/// query.batch_execute([[0], [1], [2]])
+	/// ```
+	/// Returns: `[[0,1], [1,2], [2,3]]`
+	Variant batch_execute(Array p_rows);
+
+	void finalize();
+
+private:
+	bool prepare();
+};
+
 class SQLite : public Reference {
 	GDCLASS(SQLite, Reference);
+
+	friend class SQLiteQuery;
 
 private:
 	// sqlite handler
@@ -19,11 +85,15 @@ private:
 	spmemvfs_db_t p_db;
 	bool memory_read;
 
+	Vector<WeakRef *> queries;
+
 	sqlite3_stmt *prepare(const char *statement);
 	Array fetch_rows(String query, Array args, int result_type = RESULT_BOTH);
+	sqlite3 *get_handler() const { return memory_read ? p_db.handle : db; }
 	Dictionary parse_row(sqlite3_stmt *stmt, int result_type);
-	sqlite3 *get_handler() { return (memory_read ? p_db.handle : db); }
-	bool bind_args(sqlite3_stmt *stmt, Array args);
+
+public:
+	static bool bind_args(sqlite3_stmt *stmt, Array args);
 
 protected:
 	static void _bind_methods();
@@ -35,15 +105,20 @@ public:
 		RESULT_ASSOC
 	};
 
-	// constructor
 	SQLite();
 	~SQLite();
-	void _init() {}
 
 	// methods
 	bool open(String path);
+	bool open_in_memory();
 	bool open_buffered(String name, PoolByteArray buffers, int64_t size);
 	void close();
+
+	/// Compiles the query into bytecode and returns an handle to it for a faster
+	/// execution.
+	/// Note: you can create the query at any time, but you can execute it only
+	/// when the DB is open.
+	Ref<SQLiteQuery> create_query(String p_query);
 
 	bool query(String statement);
 	bool query_with_args(String statement, Array args);
@@ -51,5 +126,7 @@ public:
 	Array fetch_array_with_args(String statement, Array args);
 	Array fetch_assoc(String statement);
 	Array fetch_assoc_with_args(String statement, Array args);
+
+	String get_last_error_message() const;
 };
 #endif


### PR DESCRIPTION
## SQLiteQuery class
Added the possibility to bake a query so to speeding up the execution.
The added `SQLiteQuery` class has the possibility to execute the query and to execute it in batch.

```GDScript
var query = db.create_query("SELECT * FROM table_name;")
print(query.execute())
# prints: [[0, 1],[1, 1],[2, 1]]
```

You can also pass some arguments:
```GDScript
var query = db.create_query("INSERT INTO table_name (column1, column2) VALUES (?, ?);")
print(query.execute([0,1]))
# prints: []
```

## Open the DB in memory for volatile usage.
```GDScript
var db = SQLite.new()
db.open_in_memory()
```