### PR TITLE
Fix build error due to missing ERR_PRINTS

### DIFF
--- a/sqlite.cpp
+++ b/sqlite.cpp
@@ -44,7 +44,7 @@ Array fast_parse_row(sqlite3_stmt *stmt) {
 				// Nothing to do.
 			} break;
 			default:
-				ERR_PRINTS("This kind of data is not yet supported: " + itos(col_type));
+				ERR_PRINT("This kind of data is not yet supported: " + itos(col_type));
 				break;
 		}
 


### PR DESCRIPTION
`ERR_PRINTS` is removed in Godot 3.x in favor of `ERR_PRINT`: https://github.com/godotengine/godot/pull/49653.